### PR TITLE
remove unused dev dependency morgan

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "express": "^4.12.4",
     "jade": "^1.10.0",
     "mocha": "^2.2.5",
-    "morgan": "^1.5.3",
     "supertest": "^1.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
Couldn't find any references to it in the project.

```
 $ grep -r morgan examples/ tests/ index.js
```