### PR TITLE
rewrite tests with unexpected express

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function(fn) {
 
     res.end = function(chunk, encoding, cb) {
       debug('end called');
-      var args = Array.prototype.slice.call(arguments, 1);
+      var args = Array.prototype.slice.call(arguments);
       if( intercept(chunk,encoding) ){
         isIntercepting = false;
         var oldBody = chunks.join('');

--- a/package.json
+++ b/package.json
@@ -41,14 +41,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "chai": "^2.3.0",
     "cheerio": "^0.19.0",
     "express": "^4.12.4",
     "jade": "^1.10.0",
     "magicpen-media": "1.5.0",
     "messy": "6.5.0",
     "mocha": "^2.2.5",
-    "supertest": "^1.0.1",
     "unexpected": "9.2.1",
     "unexpected-express": "7.3.0",
     "unexpected-messy": "4.6.0"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,13 @@
     "cheerio": "^0.19.0",
     "express": "^4.12.4",
     "jade": "^1.10.0",
+    "magicpen-media": "1.5.0",
+    "messy": "6.5.0",
     "mocha": "^2.2.5",
-    "supertest": "^1.0.1"
+    "supertest": "^1.0.1",
+    "unexpected": "9.2.1",
+    "unexpected-express": "7.3.0",
+    "unexpected-messy": "4.6.0"
   },
   "dependencies": {
     "debug": "^2.2.0"

--- a/tests/afterSend.test.js
+++ b/tests/afterSend.test.js
@@ -1,8 +1,14 @@
-var request = require('supertest');
-var expect  = require('chai').expect;
 var fs      = require('fs');
-
 var app = require('../examples/afterSend');
+var expect = require('unexpected')
+    .clone()
+    .installPlugin(require('unexpected-express'))
+    .addAssertion('to yield response', function (expect, subject, value) {
+        return expect(app, 'to yield exchange', {
+            request: subject,
+            response: value
+        });
+    });
 
 function cleanupLog(done){
   fs.exists('body.log', function (exists) {
@@ -18,18 +24,12 @@ describe('Using the after() method', function() {
 
   before(cleanupLog);
 
-  it('should intercept the generated .html and respond with the same .html', function(done) {
-    request(app)
-      .get('/README.md')
-      .expect(200)
-      .end(done);
+  it('should intercept the generated .html and respond with the same .html', function() {
+    return expect('/README.md', 'to yield response', 200);
   });
 
-  it('verify log file exist', function(done) {
-    fs.exists('body.log', function(exist) {
-      expect(exist).to.equal(true);
-      done();
-    });
+  it('verify log file exist', function() {
+    return expect(fs.existsSync('body.log'), 'to be true');
   });
 
   after(cleanupLog);

--- a/tests/json.test.js
+++ b/tests/json.test.js
@@ -1,45 +1,48 @@
-var request = require('supertest');
-var expect  = require('chai').expect;
 var fs      = require('fs');
-
 var app = require('../examples/json');
+var expect = require('unexpected')
+    .clone()
+    .installPlugin(require('unexpected-express'))
+    .addAssertion('to yield response', function (expect, subject, value) {
+        return expect(app, 'to yield exchange', {
+            request: subject,
+            response: value
+        });
+    });
 
 describe('JSON wrapping a response', function() {
 
-  it('should get a .json file and respond with a .json wraping that file', function(done) {
-    request(app)
-      .get('/package.json')
-      .expect(200)
-      .end(function(err,res) {
-        expect(res.headers['content-type']).to.equal('application/json');
-        var package_json = fs.readFileSync(__dirname + '/../package.json');
-        expect(res.body.json).to.equal(package_json.toString('utf8'));
-        done(err);
-      });
+  it('should get a .json file and respond with a .json wraping that file', function() {
+    return expect('/package.json', 'to yield response', {
+      headers: {
+          'Content-Type': 'application/json'
+      },
+      body: {
+        json: fs.readFileSync(__dirname + '/../package.json', 'utf-8')
+      }
+    });
   });
 
-  it('should get a .html file and respond with a .json wraping that file', function(done) {
-    request(app)
-      .get('/examples/static/index.html')
-      .expect(200)
-      .end(function(err,res) {
-        expect(res.headers['content-type']).to.equal('application/json');
-        var index = fs.readFileSync(__dirname + '/../examples/static/index.html');
-        expect(res.body.json).to.equal(index.toString('utf8'));
-        done(err);
-      });
+  it('should get a .html file and respond with a .json wraping that file', function() {
+    return expect('/examples/static/index.html', 'to yield response', {
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: {
+            json: fs.readFileSync(__dirname + '/../examples/static/index.html', 'utf-8')
+        }
+    });
   });
 
-  it('should get a .md file and respond with a .json wraping that file', function(done) {
-    request(app)
-      .get('/README.md')
-      .expect(200)
-      .end(function(err,res) {
-        expect(res.headers['content-type']).to.equal('application/json');
-        var readme = fs.readFileSync(__dirname + '/../README.md');
-        expect(res.body.json).to.equal(readme.toString('utf8'));
-        done(err);
-      });
+  it('should get a .md file and respond with a .json wraping that file', function() {
+    return expect('/README.md', 'to yield response', {
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: {
+            json: fs.readFileSync(__dirname + '/../README.md', 'utf-8')
+        }
+    });
   });
 
 });

--- a/tests/mirror.test.js
+++ b/tests/mirror.test.js
@@ -1,62 +1,54 @@
-var request = require('supertest');
-var expect  = require('chai').expect;
-var fs      = require('fs');
-
 var app = require('../examples/mirror');
+var fs = require('fs');
+var expect = require('unexpected')
+    .clone()
+    .installPlugin(require('unexpected-express'))
+    .addAssertion('to yield response', function (expect, subject, value) {
+        return expect(app, 'to yield exchange', {
+            request: subject,
+            response: value
+        });
+    })
+    .addAssertion('to mirror the file on disk', function (expect, subject) {
+        var fileName = subject.replace(/^\//, '');
+        var pathToFileOnDisk = require('path').resolve(__dirname, '..', fileName);
+        var fileContent = fs.readFileSync(pathToFileOnDisk, 'utf-8')
+
+        if (/\.json$/.test(fileName)) {
+            fileContent = JSON.parse(fileContent);
+        }
+
+        return expect(app, 'to yield exchange', {
+            request: subject,
+            response: {
+                body: fileContent
+            }
+        });
+    });
 
 describe('Mirroring the response', function() {
 
-  it('should intercept a .json and respond with the same .json', function(done) {
-    request(app)
-      .get('/package.json')
-      .expect(200)
-      .end(function(err, res) {
-        expect(res.body).to.deep.equal(require('../package.json'));
-        done(err);
-      });
+  it('should intercept a .json and respond with the same .json', function() {
+    return expect('/package.json', 'to mirror the file on disk');
   });
 
-  it('should intercept a .html and respond with the same .html', function(done) {
-    request(app)
-      .get('/examples/static/index.html')
-      .expect(200)
-      .end(function(err, res) {
-        var index = fs.readFileSync(__dirname + '/../examples/static/index.html');
-        expect(res.text).to.equal(index.toString('utf8'));
-        done(err);
-      });
+  it('should intercept a .html and respond with the same .html', function() {
+    return expect('/examples/static/index.html', 'to mirror the file on disk');
   });
 
-  it('should intercept a .md and respond with the same .md', function(done) {
-    request(app)
-      .get('/README.md')
-      .expect(200)
-      .end(function(err, res) {
-        var readme = fs.readFileSync(__dirname + '/../README.md');
-        expect(res.text).to.equal(readme.toString('utf8'));
-        done(err);
-      });
+  it('should intercept a .md and respond with the same .md', function() {
+    return expect('/README.md', 'to mirror the file on disk');
   });
 
-  it('should intercept a .js and respond with the same .js', function(done) {
-    request(app)
-      .get('/index.js')
-      .expect(200)
-      .end(function(err, res) {
-        var index = fs.readFileSync(__dirname + '/../index.js');
-        expect(res.text).to.equal(index.toString('utf8'));
-        done(err);
-      });
+  it('should intercept a .js and respond with the same .js', function() {
+    return expect('/index.js', 'to mirror the file on disk');
   });
 
-  it('should intercept 404 and respond with the same 404', function(done) {
-    request(app)
-      .get('/not-here.json')
-      .expect(404)
-      .end(function(err, res) {
-        expect(res.text).to.equal('Cannot GET /not-here.json\n');
-        done(err);
-      });
+  it('should intercept 404 and respond with the same 404', function() {
+    return expect('/not-here.json', 'to yield response', {
+      statusCode: 404,
+      // body: 'Cannot GET /not-here.json'
+    });
   });
 
 });

--- a/tests/mirror.test.js
+++ b/tests/mirror.test.js
@@ -45,10 +45,7 @@ describe('Mirroring the response', function() {
   });
 
   it('should intercept 404 and respond with the same 404', function() {
-    return expect('/not-here.json', 'to yield response', {
-      statusCode: 404,
-      // body: 'Cannot GET /not-here.json'
-    });
+    return expect('/not-here.json', 'to yield response', 404);
   });
 
 });

--- a/tests/modify_html.test.js
+++ b/tests/modify_html.test.js
@@ -1,42 +1,33 @@
-var request = require('supertest');
-var expect  = require('chai').expect;
-var fs      = require('fs');
-
+var fs = require('fs');
 var app = require('../examples/modify_html');
+var expect = require('unexpected')
+    .clone()
+    .installPlugin(require('unexpected-express'))
+    .addAssertion('to yield response', function (expect, subject, value) {
+        return expect(app, 'to yield exchange', {
+            request: subject,
+            response: value
+        });
+    });
+
 
 describe('Expecting only html responses', function() {
 
-  it('should intercept the generated .html (after template engine) and respond with a modified html', function(done) {
-    request(app)
-      .get('/index')
-      .expect(200)
-      .end(function(err, res) {
-        var index = '<html><head></head><body><p>&quot;Hello world&quot; from interceptor!</p></body></html>';
-        expect(res.text).to.equal(index);
-        done(err);
-      });
+  it('should intercept the generated .html (after template engine) and respond with a modified html', function() {
+    var index = '<html><head></head><body><p>&quot;Hello world&quot; from interceptor!</p></body></html>';
+    return expect('/index', 'to yield response', index);
   });
 
-  it('should intercept the .html (from a static file) and respond with a modified html', function(done) {
-    request(app)
-      .get('/')
-      .expect(200)
-      .end(function(err, res) {
-        var index = '<html><head></head><body><p>&quot;Hello world&quot; from interceptor!</p></body></html>';
-        expect(res.text).to.equal(index);
-        done(err);
-      });
+  it('should intercept the .html (from a static file) and respond with a modified html', function() {
+    var index = '<html><head></head><body><p>&quot;Hello world&quot; from interceptor!</p></body></html>';
+    return expect('/index', 'to yield response', index);
   });
 
-  it('should intercept the .json (from a static file) and return it without modification', function(done) {
-    request(app)
-      .get('/index.json')
-      .expect(200)
-      .end(function(err, res) {
-        var indexJson = fs.readFileSync(__dirname + '/../examples/static/index.json');
-        expect(res.text).to.equal(indexJson.toString('utf8'));
-        done(err);
-      });
+  it('should intercept the .json (from a static file) and return it without modification', function() {
+    var indexJson = fs.readFileSync(__dirname + '/../examples/static/index.json', 'utf-8');
+    return expect('/index.json', 'to yield response', {
+        body: JSON.parse(indexJson)
+    });
   });
 
 });

--- a/tests/non_streaming_reponses.test.js
+++ b/tests/non_streaming_reponses.test.js
@@ -1,0 +1,31 @@
+var app = require('../examples/mirror');
+var fs = require('fs');
+
+var app = require('express')()
+    .use(require('../')(function (req, res) {
+        return {
+            isInterceptable: function () {
+                return false;
+            },
+            intercept: function (body, send) {}
+        }
+    }))
+    .get('/hello', function (req, res) {
+        res.status(200).send('world');
+    });
+
+var expect = require('unexpected')
+    .clone()
+    .installPlugin(require('unexpected-express'))
+    .addAssertion('to yield response', function (expect, subject, value) {
+        return expect(app, 'to yield exchange', {
+            request: subject,
+            response: value
+        });
+    });
+
+describe('Non streaming responses', function () {
+    it('should not be swallowed when sent by .send', function () {
+        return expect('/hello', 'to yield response', 'world');
+    });
+});

--- a/tests/non_streaming_reponses.test.js
+++ b/tests/non_streaming_reponses.test.js
@@ -11,7 +11,12 @@ var app = require('express')()
         }
     }))
     .get('/hello', function (req, res) {
+        res.setHeader('Content-Type', 'text/plain');
         res.status(200).send('world');
+    })
+    .get('/hello2', function (req, res) {
+        res.setHeader('Content-Type', 'text/plain');
+        res.status(200).end('world');
     });
 
 var expect = require('unexpected')
@@ -27,5 +32,8 @@ var expect = require('unexpected')
 describe('Non streaming responses', function () {
     it('should not be swallowed when sent by .send', function () {
         return expect('/hello', 'to yield response', 'world');
+    });
+    it('should not be swallowed when sent by .end', function () {
+        return expect('/hello2', 'to yield response', 'world');
     });
 });

--- a/tests/template_engine.test.js
+++ b/tests/template_engine.test.js
@@ -1,19 +1,19 @@
-var request = require('supertest');
-var expect  = require('chai').expect;
-var fs      = require('fs');
-
 var app = require('../examples/template_engine');
+var expect = require('unexpected')
+    .clone()
+    .installPlugin(require('unexpected-express'))
+    .addAssertion('to yield response', function (expect, subject, value) {
+        return expect(app, 'to yield exchange', {
+            request: subject,
+            response: value
+        });
+    });
 
 describe('Using a template engine (Jade)', function() {
 
-  it('should intercept the generated .html and respond with the same .html', function(done) {
-    request(app)
-      .get('/index')
-      .expect(200)
-      .end(function(err, res) {
-        var hack = '<script>alert("you were intercepted!")</script>';
-        expect(res.text).to.contain(hack);
-        done(err);
+  it('should intercept the generated .html and respond with the same .html', function() {
+      return expect('/index', 'to yield response', {
+          body: expect.it('to contain', '<script>alert("you were intercepted!")</script>')
       });
   });
 


### PR DESCRIPTION
The last commit on this PR contains a fix to #22. I know that it's bad practice to include more than one change in a PR, but the bug that it fixes is what caused me to rewrite the test suite in the first case.

supertest makes it anything but easy to work with these kinds of tests. For one, it masked this error for you (where your middleware ate the chunk that can get passed to res.end. I still don't understand why, but it ended up in .text on the response object, which is a property that supertest puts there, which is not in express, and which will never make it to the client sending the request.

I didn't rewrite any of the existing tests, all of them are functionally equivalent.

The tests give way better output when they fail now too, which is one of the core goals of the unexpected testing framework.

You might find the documentation site for unexpected and the readme for unexpected-express useful:
http://unexpected.github.io
https://github.com/unexpectedjs/unexpected-express

If you have any questions, don't hesitate to ask questions!