### PR TITLE
Replace fs.existsSync in afterSend test.

### DIFF
--- a/tests/afterSend.test.js
+++ b/tests/afterSend.test.js
@@ -29,7 +29,9 @@ describe('Using the after() method', function() {
   });
 
   it('verify log file exist', function() {
-    return expect(fs.existsSync('body.log'), 'to be true');
+      return expect(function (cb) {
+          fs.open('body.log', 'r', cb);
+      }, 'to call the callback without error');
   });
 
   after(cleanupLog);


### PR DESCRIPTION
fs.exists and fs.existsSync will be deprecated. Replaces the test case with a
test making sure that the file can be opened for reading.

Fixes #26 