### PR TITLE
Update unexpected to 9.5.0 and unexpected-express to 7.7.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,9 @@
     "cheerio": "^0.19.0",
     "express": "^4.12.4",
     "jade": "^1.10.0",
-    "magicpen-media": "1.5.0",
-    "messy": "6.5.0",
     "mocha": "^2.2.5",
-    "unexpected": "9.2.1",
-    "unexpected-express": "7.3.0",
-    "unexpected-messy": "4.6.0"
+    "unexpected": "9.5.0",
+    "unexpected-express": "7.7.0"
   },
   "dependencies": {
     "debug": "^2.2.0"


### PR DESCRIPTION
This allows us to get rid of the 3 annoying extra devDependencies that were added as a result of `npm install --save dev unexpected unexpected-express`, while remaining compatible with both npm 2 and 3.

You might need to remove your existing node_modules folder before running `npm install` if you get an EPEERINVALID error.