### PR TITLE
feat!: Do not parse response data as utf-8

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function(fn) {
 
       if (intercept(chunk,encoding)) {
         isIntercepting = false;
-        var oldBody = Buffer.concat(chunks).toString('utf-8');
+        var oldBody = Buffer.concat(chunks);
 
         if (methods.intercept) {
           if (typeof methods.intercept !== 'function') {


### PR DESCRIPTION
Parsing binary data as utf-8 can cause problems, e.g. pdf file. Parsing as utf-8 replaces bytes that cannot be parsed with replacement character - https://en.wikipedia.org/wiki/Specials_(Unicode_block)#:~:text=The%20replacement%20character%20%EF%BF%BD%20(often,data%20to%20a%20correct%20symbol

For example bytes FB, FC, FD will each be replaced with replacement character which is 3 bytes long and the result will look like this -  EF BF BD, EF BF BD, EF BF BD

BREAKING CHANGE: Changes the type of oldBody argument from string to Buffer