### PR TITLE
fix: remove checking cb which is not in function scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,6 @@ module.exports = function(fn) {
           }
           chunks.push(chunk);
         }
-        if (typeof cb === 'function') {
-          cb();
-        }
       }
 
       return isIntercepting;


### PR DESCRIPTION
Most times it will be ok, unless there is a global called cb.